### PR TITLE
Translation lookup permits presenters

### DIFF
--- a/lib/formulaic/form.rb
+++ b/lib/formulaic/form.rb
@@ -18,6 +18,7 @@ module Formulaic
 
     def initialize(model_name, action, attributes)
       @action = action
+      @presenter = attributes.delete(:presenter)
       @inputs = build_inputs(model_name, attributes)
     end
 
@@ -27,7 +28,7 @@ module Formulaic
 
     private
 
-    attr_reader :model_name, :inputs, :action
+    attr_reader :model_name, :inputs, :action, :presenter
 
     def build_inputs(model_name, attributes)
       attributes.map do |field, value|
@@ -36,7 +37,7 @@ module Formulaic
     end
 
     def build_input(model_name, field, value)
-      label = Label.new(model_name, field, action)
+      label = Label.new(model_name, field, action, presenter)
       input_class_for(value).new(label, value)
     end
 

--- a/lib/formulaic/label.rb
+++ b/lib/formulaic/label.rb
@@ -1,11 +1,12 @@
 module Formulaic
   class Label
-    attr_reader :model_name, :attribute, :action
+    attr_reader :model_name, :attribute, :action, :presenter
 
-    def initialize(model_name, attribute, action)
+    def initialize(model_name, attribute, action, presenter)
       @model_name = model_name
       @attribute = attribute
       @action = action
+      @presenter = presenter
     end
 
     def to_str
@@ -34,6 +35,7 @@ module Formulaic
 
     def lookup_paths
       [
+        :"#{model_name}.#{attribute}.#{presenter}",
         :"#{model_name}.#{action}.#{attribute}",
         :"#{model_name}.#{attribute}",
         :"defaults.#{action}.#{attribute}",

--- a/spec/formulaic/label_spec.rb
+++ b/spec/formulaic/label_spec.rb
@@ -9,10 +9,20 @@ describe Formulaic::Label do
 
   context "attribute is not a string" do
     context "translation is available" do
-      it "uses a translation" do
-        create_translation_for({ user: { name: "First name"}})
+      context "no presenter provided" do
+        it "uses a translation" do
+          create_translation_for({ user: { name: "First name"}})
 
-        expect(label(:user, :name)).to eq("First name")
+          expect(label(:user, :name)).to eq("First name")
+        end
+      end
+
+      context "presenter provided" do
+        it "uses a translation" do
+          create_translation_for({ user: { name: { presenter: "First name"}}})
+
+          expect(label(:user, :name, presenter: :presenter)).to eq("First name")
+        end
       end
     end
 
@@ -35,8 +45,8 @@ describe Formulaic::Label do
     end
   end
 
-  def label(model_name, attribute, action = :new)
-    Formulaic::Label.new(model_name, attribute, action).to_str
+  def label(model_name, attribute, action = :new, presenter: :nil)
+    Formulaic::Label.new(model_name, attribute, action, presenter).to_str
   end
 
   def create_translation_for(label)


### PR DESCRIPTION
- Some people use presenters to specify different translations for
  different types of users. This commit allows our tests to be as
  dynamic as our views.
